### PR TITLE
fix: silence Sass if-function deprecation from Bootstrap 5

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -92,7 +92,7 @@ module.exports = {
       resolve: 'gatsby-plugin-sass',
       options: {
         sassOptions: {
-          silenceDeprecations: ['legacy-js-api', 'import', 'global-builtin', 'color-functions'],
+          silenceDeprecations: ['legacy-js-api', 'import', 'global-builtin', 'color-functions', 'if-function'],
         },
         additionalData: `@import "${__dirname}/src/scss/_variables";`,
       },


### PR DESCRIPTION
## Summary
- Adds `if-function` to `silenceDeprecations` in `gatsby-plugin-sass` config
- Warnings come from Bootstrap 5's own SCSS internals, not our code
- Bootstrap 6 will resolve this properly; this is the official Sass-recommended workaround for third-party deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)