### PR TITLE
fix: update Mapy.cz link to mapy.com

### DIFF
--- a/src/pages/kontakt.astro
+++ b/src/pages/kontakt.astro
@@ -42,7 +42,7 @@ import adresaImg from '../assets/images/adresa.png'
     <div class="container">
       <p>
         Odkazy:&nbsp;<a href="https://goo.gl/maps/TtFt2ZCFAeM2">Mapy Google</a
-        >&nbsp;|&nbsp;<a href="https://mapy.cz/s/3dAHc">Mapy.cz</a>
+        >&nbsp;|&nbsp;<a href="https://mapy.com/s/3dAHc">Mapy.com</a>
       </p>
       <p>
         GPS souřadnice: <strong>49.23841N</strong>,&nbsp;<strong>16.5828108E</strong>


### PR DESCRIPTION
## Summary

- Updates the Mapy.cz link on the contact page to the rebranded domain `mapy.com`

## Test plan

- [ ] Kontakt page: Mapy.com link opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)