### PR TITLE
fix: clear stale service workers and enforce no-cache on HTML

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,11 @@
   publish = "dist"
 
 [[headers]]
+  for = "/*"
+  [headers.values]
+    Cache-Control = "no-cache, no-store, must-revalidate"
+
+[[headers]]
   for = "/_astro/*"
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vetgalen.cz",
   "description": "Vetgalen.cz",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/vetgalen/vetgalen.cz"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -67,5 +67,15 @@ const pathname = Astro.url.pathname
     <script>
       import 'bootstrap'
     </script>
+    <script is:inline>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.getRegistrations().then(function (registrations) {
+          registrations.forEach(function (r) { r.unregister() })
+        })
+        caches.keys().then(function (keys) {
+          keys.forEach(function (key) { caches.delete(key) })
+        })
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- Adds inline `is:inline` script to `Layout.astro` that unregisters all service workers and clears browser caches on page load — self-heals affected users without any manual DevTools steps
- Adds `Cache-Control: no-cache, no-store, must-revalidate` for `/*` in `netlify.toml` so HTML pages always revalidate; hashed `/_astro/*` assets keep their immutable year-long cache
- Bumps version to 2.2.0

## Test plan

- [ ] Deploy preview loads without blank page
- [ ] `curl -I https://www.vetgalen.cz/` shows `cache-control: no-cache, no-store, must-revalidate`
- [ ] `curl -I https://www.vetgalen.cz/_astro/<any-hashed-asset>` still shows `cache-control: public, max-age=31536000, immutable`
- [ ] DevTools → Application → Service Workers shows no registered workers after visiting the deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)